### PR TITLE
support item props for custom

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -28,7 +28,7 @@ export function extractOpenGraph(
   // find all the open graph info in the meta tags
   $('meta').each((index, meta: TagElement) => {
     if (!meta.attribs || (!meta.attribs.property && !meta.attribs.name)) return;
-    const property = meta.attribs.property || meta.attribs.name;
+    const property = meta.attribs.property || meta.attribs.name || meta.attribs.itemprop || meta.attribs.itemProp;
     const content = meta.attribs.content || meta.attribs.value;
     metaFields.forEach((item) => {
       if (property.toLowerCase() === item.property.toLowerCase()) {


### PR DESCRIPTION
Thanks for the awesome library! This is my first PR to a public repo so I hope it worked ok :)

The change intends to include `itemProp` attribute on meta tags, which didn't appear to be supported. I've been testing with this site: https://www.net-a-porter.com/en-au/shop/product/gucci/shoes/mid-heel/plastique-logo-embossed-rubber-mules/1647597276960849

It looks like you currently use itemprop only as a fall back, but when using custom tags this didn't seem to work. As such, I've added this to the src file. Thanks!